### PR TITLE
Add pull requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.2",
+    "react-router-modal": "^1.1.13",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "simple-text-parser": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.2",
     "redux": "^3.7.2",
+    "redux-thunk": "^2.2.0",
     "simple-text-parser": "^1.0.0",
     "string-hash": "^1.1.3"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,2 +1,9 @@
 .App {
 }
+.App .App-modal-backdrop {
+	background-color: rgba(50, 55, 60, 0.4);
+}
+.App .App-modal {
+	border: none;
+	box-shadow: 0 0 1px #0073aa;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Redirect, BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import { set_user_credentials } from './actions';
+import Avatar from './components/Avatar';
 import Footer from './components/Footer';
 import Header from './components/Header';
 import Login from './components/Login';
@@ -38,7 +39,9 @@ class App extends React.Component {
 		if ( ! user.username ) {
 			return <Router>
 				<div className="App">
-					<Header />
+					<Header
+						title="Not Trac"
+					/>
 					<div className="wrapper">
 						<Login
 							onSubmit={ user => dispatch( set_user_credentials( user ) ) }
@@ -52,8 +55,21 @@ class App extends React.Component {
 		return <Router>
 			<div className="App">
 				<Header
+					title="Not Trac"
 					user={ user }
-				/>
+				>
+					{ user ?
+						<ul>
+							<li>
+								<Link to="/">Components</Link>
+							</li>
+							<li>
+								<Avatar size={ 24 } user={ user.username } />
+								@{ user.username }
+							</li>
+						</ul>
+					: null }
+				</Header>
 				<div className="wrapper">
 					<Switch>
 						<Route

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
 import qs from 'query-string';
 import React from 'react';
 import { connect } from 'react-redux';
-import { Redirect, BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { Link, Redirect, BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { ModalContainer } from 'react-router-modal';
 
 import { set_user_credentials } from './actions';
 import Avatar from './components/Avatar';
@@ -15,6 +16,7 @@ import Summary from './containers/Summary';
 import Ticket from './containers/Ticket';
 
 import './App.css';
+import 'react-router-modal/css/react-router-modal.css';
 
 class App extends React.Component {
 	constructor( props ) {
@@ -126,6 +128,10 @@ class App extends React.Component {
 					</Switch>
 				</div>
 				<Footer />
+				<ModalContainer
+					backdropClassName="react-router-modal__backdrop App-modal-backdrop"
+					modalClassName="react-router-modal__modal App-modal"
+				/>
 			</div>
 		</Router>;
 	}

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,7 @@
 export const PUSH_ATTACHMENT = 'PUSH_ATTACHMENT';
 export const PUSH_TICKET_CHANGE = 'PUSH_TICKET_CHANGE';
+export const RECEIVE_PRS = 'RECEIVE_PRS';
+export const REQUEST_PRS = 'REQUEST_PRS';
 export const SET_COMPONENTS = 'SET_COMPONENTS';
 export const SET_QUERY_PARAMS = 'SET_QUERY_PARAMS';
 export const SET_QUERY_RESULTS = 'SET_QUERY_RESULTS';
@@ -42,4 +44,19 @@ export function set_ticket_data( id, data ) {
 
 export function set_user_credentials( user ) {
 	return { type: SET_USER_CREDENTIALS, user };
+}
+
+export function update_prs() {
+	return (dispatch, getStore) => {
+		dispatch( { type: REQUEST_PRS } );
+
+		fetch( 'https://api.github.com/repos/WordPress/wordpress-develop/pulls?state=all' )
+			.then( resp => resp.json() )
+			.then( data => {
+				dispatch({
+					type: RECEIVE_PRS,
+					prs: data,
+				});
+			});
+	}
 }

--- a/src/components/AttachmentUpload.js
+++ b/src/components/AttachmentUpload.js
@@ -78,6 +78,15 @@ export default class AttachmentUpload extends React.PureComponent {
 		});
 	}
 
+	onSelectPull( pull, file ) {
+		const description = `${ pull.title } (From ${ pull.html_url })`;
+
+		this.setState({
+			description,
+			file,
+		});
+	}
+
 	onDragOver( e ) {
 		e.preventDefault();
 
@@ -145,6 +154,7 @@ export default class AttachmentUpload extends React.PureComponent {
 							state={ prs.state }
 							onCancel={ () => this.setState({ showingPullSelector: false }) }
 							onReload={ this.props.onLoadPulls }
+							onSelect={ ( pull, file ) => this.onSelectPull( pull, file ) }
 						/>
 					</Modal>
 				: null }

--- a/src/components/AttachmentUpload.js
+++ b/src/components/AttachmentUpload.js
@@ -1,8 +1,10 @@
 import base64 from 'base64-js';
 import bytes from 'bytes';
 import React from 'react';
+import { Modal } from 'react-router-modal';
 
 import Button from './Button';
+import PullRequests from './PullRequests';
 import Spinner from './Spinner';
 
 import './AttachmentUpload.css';
@@ -13,6 +15,7 @@ const INITIAL_STATE = {
 	file: null,
 	licenseAgree: false,
 	progress: 0,
+	showingPullSelector: false,
 	uploading: false,
 	uploadMessage: '',
 };
@@ -106,6 +109,7 @@ export default class AttachmentUpload extends React.PureComponent {
 	}
 
 	render() {
+		const { prs, ticket } = this.props;
 		const { file, licenseAgree } = this.state;
 
 		if ( ! file ) {
@@ -123,9 +127,27 @@ export default class AttachmentUpload extends React.PureComponent {
 						/>
 						<Button fake>Upload an Attachment</Button>
 					</label>
-					{/*<Button>Attach a Pull Request</Button>*/}
+					{ prs ?
+						<Button
+							onClick={ () => this.setState({ showingPullSelector: true }) }
+						>
+							Attach a Pull Request
+						</Button>
+					: null }
 					<span>(Or drop files here.)</span>
 				</p>
+
+				{ prs && this.state.showingPullSelector ?
+					<Modal>
+						<PullRequests
+							id={ ticket.id }
+							items={ prs.items }
+							state={ prs.state }
+							onCancel={ () => this.setState({ showingPullSelector: false }) }
+							onReload={ this.props.onLoadPulls }
+						/>
+					</Modal>
+				: null }
 			</div>;
 		}
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,31 +1,18 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-
-import Avatar from './Avatar';
 
 import './Header.css';
 
 export default class Header extends React.PureComponent {
 	render() {
-		const { user } = this.props;
+		const { children, title } = this.props;
 
 		return <div className="Header">
 			<div className="wrapper">
-				<h1>Not Trac</h1>
+				<h1>{ title }</h1>
 
-				{ user ?
-					<nav>
-						<ul>
-							<li>
-								<Link to="/">Components</Link>
-							</li>
-							<li>
-								<Avatar size={ 24 } user={ user.username } />
-								@{ user.username }
-							</li>
-						</ul>
-					</nav>
-				: null }
+				<nav>
+					{ children }
+				</nav>
 			</div>
 		</div>;
 	}

--- a/src/components/ListTable.css
+++ b/src/components/ListTable.css
@@ -1,4 +1,4 @@
-.TicketList {
+.ListTable {
 	list-style: none;
 	margin: 0;
 	padding: 0;

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import './ListTable.css';
+
+export default ({ children }) => <ul className="ListTable">{ children }</ul>;

--- a/src/components/ListTableItem.css
+++ b/src/components/ListTableItem.css
@@ -1,0 +1,30 @@
+.ListTableItem {
+	display: flex;
+	border: 1px solid #bfe7f3;
+	border-bottom-style: none;
+	padding: 0.7em;
+}
+
+.ListTableItem:hover {
+	background: #e5f5fa;
+}
+
+.ListTableItem:last-of-type {
+	border-bottom-style: solid;
+}
+
+.ListTableItem > .col-main {
+	flex-grow: 1;
+	line-height: 1.6;
+}
+
+.ListTableItem .col-main-title {
+	font-weight: bold;
+	margin: 0;
+}
+.ListTableItem .col-main-title:hover {
+	color: #00a0d2;
+}
+.ListTableItem .col-main-title a {
+	color: inherit;
+}

--- a/src/components/ListTableItem.js
+++ b/src/components/ListTableItem.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import './ListTableItem.css';
+
+export default ({ children, className }) => (
+	<li
+		children={ children }
+		className={ `ListTableItem ${className}` }
+	/>
+);

--- a/src/components/ListTableItem.js
+++ b/src/components/ListTableItem.js
@@ -5,6 +5,6 @@ import './ListTableItem.css';
 export default ({ children, className }) => (
 	<li
 		children={ children }
-		className={ `ListTableItem ${className}` }
+		className={ `ListTableItem ${ className || '' }` }
 	/>
 );

--- a/src/components/PullRequests.css
+++ b/src/components/PullRequests.css
@@ -1,0 +1,19 @@
+.PullRequests {
+	width: 80vw;
+	height: 80vh;
+	max-width: 960px;
+}
+.PullRequests-content {
+	padding: 1rem;
+}
+.PullRequests-state {
+	font-size: 0.9em;
+	padding-top: 3px;
+}
+
+.PullRequests .col-main-title .dashicons {
+	font-size: 1em;
+	height: 1em;
+	width: 1em;
+	vertical-align: baseline;
+}

--- a/src/components/PullRequests.js
+++ b/src/components/PullRequests.js
@@ -5,12 +5,13 @@ import Header from './Header';
 import ListTable from './ListTable';
 import ListTableItem from './ListTableItem';
 import Loading from './Loading';
+import Spinner from './Spinner';
 import TicketState from './TicketState';
 import Time from './Time';
 
 import './PullRequests.css';
 
-const PullRequestItem = ({ item }) => {
+const PullRequestItem = ({ item, loading, onSelect }) => {
 	return <ListTableItem>
 		<div className="PullRequests-state">
 			<TicketState
@@ -35,14 +36,52 @@ const PullRequestItem = ({ item }) => {
 			</small>
 		</div>
 		<div>
-			<Button>Select</Button>
+			{ loading ?
+				<Button fake>
+					<Spinner />
+					{ ' Loading' }
+					&hellip;
+				</Button>
+			:
+				<Button onClick={ onSelect }>Select</Button>
+			}
 		</div>
 	</ListTableItem>;
 };
 
 export default class PullRequests extends React.PureComponent {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			loading: null,
+		};
+	}
+
+	onSelect( pull ) {
+		const { id } = this.props;
+
+		// Start the loader.
+		this.setState({ loading: pull.id });
+
+		// Build diff URL manually to avoid CORS problems.
+		const diff_url = `https://api.github.com/repos/WordPress/wordpress-develop/pulls/${ pull.number }`;
+		const headers = {
+			Accept: 'application/vnd.github.v3.diff',
+		};
+		fetch( diff_url, { headers } )
+			.then( resp => resp.blob() )
+			.then( file => {
+				// Extend file with File-like properties.
+				file.name = `${ id }.diff`;
+
+				this.props.onSelect( pull, file );
+			});
+	}
+
 	render() {
 		const { id, items, state } = this.props;
+		const { loading } = this.state;
 
 		console.log( this.props );
 
@@ -70,7 +109,8 @@ export default class PullRequests extends React.PureComponent {
 							<PullRequestItem
 								key={ item.id }
 								item={ item }
-								onSelect={ () => this.props.onSelect( item ) }
+								loading={ item.id === loading }
+								onSelect={ () => this.onSelect( item ) }
 							/>
 						) }
 					</ListTable>

--- a/src/components/PullRequests.js
+++ b/src/components/PullRequests.js
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import Button from './Button';
+import Header from './Header';
+import ListTable from './ListTable';
+import ListTableItem from './ListTableItem';
+import Loading from './Loading';
+import TicketState from './TicketState';
+import Time from './Time';
+
+import './PullRequests.css';
+
+const PullRequestItem = ({ item }) => {
+	return <ListTableItem>
+		<div className="PullRequests-state">
+			<TicketState
+				state={ item.state === 'open' ? 'new' : 'closed' }
+			/>
+		</div>
+		<div className="col-main">
+			<p className="col-main-title">
+				<a href={ item.html_url } target="_blank">
+					{ item.title }
+					{ ' ' }
+					<span className="dashicons dashicons-external"></span>
+				</a>
+			</p>
+
+			<small>
+				#{ item.number }
+				{ ' opened ' }
+				<Time date={ item.created_at } />
+				{ ' by ' }
+				@{ item.user.login }
+			</small>
+		</div>
+		<div>
+			<Button>Select</Button>
+		</div>
+	</ListTableItem>;
+};
+
+export default class PullRequests extends React.PureComponent {
+	render() {
+		const { id, items, state } = this.props;
+
+		console.log( this.props );
+
+		return <div className="PullRequests">
+			<Header title={ `Attach pull request to #${ id }` }>
+				<ul>
+					<li>
+						<a onClick={ () => this.props.onReload() }>
+							Reload
+						</a>
+					</li>
+					<li>
+						<a onClick={ () => this.props.onCancel() }>
+							Cancel
+						</a>
+					</li>
+				</ul>
+			</Header>
+			<div className="PullRequests-content">
+				{ state === 'loading' ?
+					<Loading />
+				:
+					<ListTable>
+						{ items.map( item =>
+							<PullRequestItem
+								key={ item.id }
+								item={ item }
+								onSelect={ () => this.props.onSelect( item ) }
+							/>
+						) }
+					</ListTable>
+				}
+			</div>
+		</div>;
+	}
+}

--- a/src/components/PullRequests.js
+++ b/src/components/PullRequests.js
@@ -83,8 +83,6 @@ export default class PullRequests extends React.PureComponent {
 		const { id, items, state } = this.props;
 		const { loading } = this.state;
 
-		console.log( this.props );
-
 		return <div className="PullRequests">
 			<Header title={ `Attach pull request to #${ id }` }>
 				<ul>

--- a/src/components/Ticket.js
+++ b/src/components/Ticket.js
@@ -64,8 +64,8 @@ export default class Ticket extends React.PureComponent {
 
 					<TicketUpdate
 						ticket={ id }
+						uploader={ this.props.uploader }
 						onComment={ text => this.props.onComment( text ) }
-						onUpload={ this.props.onUpload }
 					/>
 				</div>
 				<TicketStatus attributes={ attributes } />

--- a/src/components/TicketChanges.js
+++ b/src/components/TicketChanges.js
@@ -80,6 +80,15 @@ export default class TicketChanges extends React.PureComponent {
 			case 'attachment': {
 				const patch = newval;
 				const icon = <span className="dashicons dashicons-upload"></span>;
+				let description = attachments && patch in attachments && attachments[ patch ].description;
+				let pullLink = null;
+				if ( description && description.indexOf( 'https://github.com/WordPress/wordpress-develop/pull/' ) ) {
+					pullLink = description.match( /(https:\/\/github.com\/WordPress\/wordpress-develop\/pull\/\d+)/i )[ 1 ];
+					description = description.replace(
+						/\(From (https:\/\/github.com\/WordPress\/wordpress-develop\/pull\/\d+)\)/,
+						''
+					);
+				}
 				return <TimelineEvent key={ key } compact icon={ icon }>
 					<p>
 						<UserLink user={ author } />
@@ -88,9 +97,9 @@ export default class TicketChanges extends React.PureComponent {
 					</p>
 					<p className="TicketChanges-attachment">
 						<Link to={ `/attachment/ticket/${ ticket }/${ patch }` }>
-							{ ( attachments && patch in attachments && attachments[ patch ].description ) ?
+							{ description ?
 								<span className="TicketChanges-attachment-desc">
-									{ attachments[ patch ].description }
+									{ description }
 								</span>
 							: null }
 							<code>{ patch }</code>
@@ -101,6 +110,15 @@ export default class TicketChanges extends React.PureComponent {
 								Uploading to Trac&hellip;
 							</span>
 						: null}
+						{ pullLink ?
+							<p>
+								<a href={ pullLink } target="_blank">
+									Open pull request
+									{ ' ' }
+									<span className="dashicons dashicons-external" />
+								</a>
+							</p>
+						: null }
 					</p>
 				</TimelineEvent>;
 			}

--- a/src/components/TicketList.js
+++ b/src/components/TicketList.js
@@ -1,15 +1,14 @@
 import React from 'react';
 
+import ListTable from './ListTable';
 import TicketListItem from './TicketListItem';
-
-import './TicketList.css';
 
 export default class TicketList extends React.PureComponent {
 	render() {
 		const { tickets } = this.props;
 
-		return <ul className="TicketList">
+		return <ListTable>
 			{ tickets.map( ticket => <TicketListItem key={ ticket.id } ticket={ ticket } /> ) }
-		</ul>
+		</ListTable>
 	}
 }

--- a/src/components/TicketListItem.css
+++ b/src/components/TicketListItem.css
@@ -1,18 +1,3 @@
-.TicketListItem {
-	display: flex;
-	border: 1px solid #bfe7f3;
-	border-bottom-style: none;
-	padding: 0.7em;
-}
-
-.TicketListItem:hover {
-	background: #e5f5fa;
-}
-
-.TicketListItem:last-of-type {
-	border-bottom-style: solid;
-}
-
 .TicketListItem > .col-type {
 	width: 2rem;
 	color: #f9a87e;
@@ -25,10 +10,6 @@
 	color: #90d296;
 }
 
-.TicketListItem > .col-main {
-	flex-grow: 1;
-}
-
 .TicketListItem > .col-main small {
 	font-size: 0.85em;
 	color: #72777C;
@@ -36,18 +17,6 @@
 
 .TicketListItem-detail-title-block {
 	display: flex;
-	line-height: 1.6;
-}
-
-.TicketListItem-detail-title {
-	font-weight: bold;
-	margin: 0;
-}
-.TicketListItem-detail-title:hover {
-	color: #00a0d2;
-}
-.TicketListItem-detail-title a {
-	color: inherit;
 }
 
 .TicketListItem-detail-tags {

--- a/src/components/TicketListItem.js
+++ b/src/components/TicketListItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import Avatar from './Avatar';
+import ListTableItem from './ListTableItem';
 import Tag from './Tag';
 import Time from './Time';
 import { getKeywords, getTicketType } from '../lib/workflow';
@@ -22,7 +23,7 @@ export default class TicketListItem extends React.PureComponent {
 
 		const type = getTicketType( ticket );
 
-		return <li className="TicketListItem">
+		return <ListTableItem className="TicketListItem">
 			<div className={ `col-type type-${ type }` }>
 				{ type === 'bug' ?
 					<span className="dashicons dashicons-warning"></span>
@@ -34,7 +35,7 @@ export default class TicketListItem extends React.PureComponent {
 			</div>
 			<div className="col-main">
 				<div className="TicketListItem-detail-title-block">
-					<p className="TicketListItem-detail-title">
+					<p className="col-main-title">
 						<Link to={ `/ticket/${ ticket.id }` }>
 							{ ticket.attributes.summary }
 						</Link>
@@ -78,6 +79,6 @@ export default class TicketListItem extends React.PureComponent {
 					}
 				</span>
 			</div>
-		</li>;
+		</ListTableItem>;
 	}
 }

--- a/src/components/TicketUpdate.js
+++ b/src/components/TicketUpdate.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import AttachmentUpload from './AttachmentUpload';
 import CommentEditor from './CommentEditor';
 import Timeline from './Timeline';
 import TimelineEvent from './TimelineEvent';
@@ -10,14 +9,14 @@ import './TicketUpdate.css';
 
 class TicketUpdate extends React.PureComponent {
 	render() {
-		const { ticket, user, onComment, onUpload } = this.props;
+		const { ticket, uploader, user, onComment } = this.props;
 		const upload_icon = <span className="dashicons dashicons-upload"></span>;
 		return <Timeline className="TicketUpdate">
-			<TimelineEvent compact icon={ upload_icon }>
-				<AttachmentUpload
-					onUpload={ onUpload }
-				/>
-			</TimelineEvent>
+			{ uploader ?
+				<TimelineEvent compact icon={ upload_icon }>
+					{ uploader }
+				</TimelineEvent>
+			: null }
 			<TimelineEvent>
 				<CommentEditor
 					ticket={ ticket }

--- a/src/components/Time.js
+++ b/src/components/Time.js
@@ -1,8 +1,14 @@
 import moment from 'moment';
 import React from 'react';
 
-export default ({ timestamp }) => {
-	const date = moment.unix( timestamp );
+export default props => {
+	let date;
+	if ( props.date ) {
+		date = moment( props.date );
+	} else {
+		date = moment.unix( props.timestamp );
+	}
+
 	return <time
 		children={ date.fromNow() }
 		dateTime={ date.toISOString() }

--- a/src/containers/AttachmentUpload.js
+++ b/src/containers/AttachmentUpload.js
@@ -8,19 +8,19 @@ class AttachmentUpload extends React.PureComponent {
 	componentDidMount() {
 		const { dispatch, prs } = this.props;
 		if ( ! prs.state ) {
-			this.props.dispatch( update_prs() );
+			dispatch( update_prs() );
 		}
 	}
 
 	onUpload( upload ) {
-		const { dispatch, id, user } = this.props;
+		const { dispatch, ticket, user } = this.props;
 		const { data, description, filename } = upload;
 
-		const ticket = parseInt( id, 10 );
+		const id = parseInt( ticket.id, 10 );
 
 		const parameters = [
 			// int ticket
-			ticket,
+			id,
 
 			// string filename
 			filename,
@@ -96,5 +96,5 @@ class AttachmentUpload extends React.PureComponent {
 }
 
 export default connect(
-	({ prs }) => ({ prs })
+	({ prs, user }) => ({ prs, user })
 )( AttachmentUpload );

--- a/src/containers/AttachmentUpload.js
+++ b/src/containers/AttachmentUpload.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { push_attachment, push_ticket_change } from '../actions';
+import AttachmentUploadComponent from '../components/AttachmentUpload';
+
+class AttachmentUpload extends React.PureComponent {
+	onUpload( upload ) {
+		const { dispatch, id, user } = this.props;
+		const { data, description, filename } = upload;
+
+		const ticket = parseInt( id, 10 );
+
+		const parameters = [
+			// int ticket
+			ticket,
+
+			// string filename
+			filename,
+
+			// string description
+			description,
+
+			// Binary data
+			data,
+
+			// boolean replace=True
+			false,
+		];
+		const types = {
+			// Binary data
+			3: 'base64',
+		};
+
+		// Optimistically render.
+		const tempTimestamp = parseInt( Date.now() / 1000, 10 );
+		const change = [
+			// timestamp
+			tempTimestamp,
+
+			// author
+			user.username,
+
+			// field
+			'attachment',
+
+			// oldval
+			'',
+
+			// newval (filename)
+			filename,
+
+			// permanent
+			true,
+		];
+		const tempAttachment = {
+			id: filename,
+			description,
+			size: 0,
+			timestamp: tempTimestamp,
+			author: user.username,
+			isUploading: true,
+		};
+		dispatch( push_ticket_change( ticket, change ) );
+		dispatch( push_attachment( ticket, tempAttachment ) );
+
+		// And finally, save.
+		this.api.call( 'ticket.putAttachment', parameters, types )
+			.then( () => {
+				// Reload changes and attachments.
+				this.loadTicketAndChanges( id, 'attachments' );
+			});
+	}
+
+	render() {
+		const { dispatch, ticket } = this.props;
+
+		if ( ! ticket ) {
+			return null;
+		}
+
+		return <AttachmentUploadComponent
+			ticket={ ticket }
+			onUpload={ upload => this.onUpload( upload ) }
+		/>;
+	}
+}
+
+export default connect(
+	() => ({ })
+)( AttachmentUpload );

--- a/src/containers/AttachmentUpload.js
+++ b/src/containers/AttachmentUpload.js
@@ -68,8 +68,8 @@ class AttachmentUpload extends React.PureComponent {
 			author: user.username,
 			isUploading: true,
 		};
-		dispatch( push_ticket_change( ticket, change ) );
-		dispatch( push_attachment( ticket, tempAttachment ) );
+		dispatch( push_ticket_change( id, change ) );
+		dispatch( push_attachment( id, tempAttachment ) );
 
 		// And finally, save.
 		this.api.call( 'ticket.putAttachment', parameters, types )

--- a/src/containers/AttachmentUpload.js
+++ b/src/containers/AttachmentUpload.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { push_attachment, push_ticket_change } from '../actions';
+import { push_attachment, push_ticket_change, update_prs } from '../actions';
 import AttachmentUploadComponent from '../components/AttachmentUpload';
 
 class AttachmentUpload extends React.PureComponent {
@@ -73,19 +73,21 @@ class AttachmentUpload extends React.PureComponent {
 	}
 
 	render() {
-		const { dispatch, ticket } = this.props;
+		const { dispatch, prs, ticket } = this.props;
 
 		if ( ! ticket ) {
 			return null;
 		}
 
 		return <AttachmentUploadComponent
+			prs={ prs }
 			ticket={ ticket }
+			onLoadPulls={ () => dispatch( update_prs() ) }
 			onUpload={ upload => this.onUpload( upload ) }
 		/>;
 	}
 }
 
 export default connect(
-	() => ({ })
+	({ prs }) => ({ prs })
 )( AttachmentUpload );

--- a/src/containers/AttachmentUpload.js
+++ b/src/containers/AttachmentUpload.js
@@ -5,6 +5,13 @@ import { push_attachment, push_ticket_change, update_prs } from '../actions';
 import AttachmentUploadComponent from '../components/AttachmentUpload';
 
 class AttachmentUpload extends React.PureComponent {
+	componentDidMount() {
+		const { dispatch, prs } = this.props;
+		if ( ! prs.state ) {
+			this.props.dispatch( update_prs() );
+		}
+	}
+
 	onUpload( upload ) {
 		const { dispatch, id, user } = this.props;
 		const { data, description, filename } = upload;

--- a/src/containers/Ticket.js
+++ b/src/containers/Ticket.js
@@ -2,6 +2,7 @@ import React from 'react';
 import DocumentTitle from 'react-document-title';
 import { connect } from 'react-redux';
 
+import AttachmentUpload from './AttachmentUpload';
 import { push_attachment, push_ticket_change, set_ticket_attachments, set_ticket_changes, set_ticket_data } from '../actions';
 import Loading from '../components/Loading';
 import TicketComponent from '../components/Ticket';
@@ -237,12 +238,17 @@ class Ticket extends React.PureComponent {
 			`#${ id }: ${ data.attributes.summary }` :
 			`#${ id }: Loading...`;
 
+		const uploader = <AttachmentUpload
+			ticket={ data }
+			onComplete={ () => this.loadTicketAndChanges( id, 'attachments' ) }
+		/>;
+
 		return <DocumentTitle title={ title }>
 			<TicketComponent
 				{ ...data }
 				id={ parseInt( id, 10 ) }
+				uploader={ uploader }
 				onComment={ text => this.onComment( text ) }
-				onUpload={ upload => this.onUpload( upload ) }
 			/>
 		</DocumentTitle>;
 	}

--- a/src/containers/Ticket.js
+++ b/src/containers/Ticket.js
@@ -3,7 +3,7 @@ import DocumentTitle from 'react-document-title';
 import { connect } from 'react-redux';
 
 import AttachmentUpload from './AttachmentUpload';
-import { push_attachment, push_ticket_change, set_ticket_attachments, set_ticket_changes, set_ticket_data } from '../actions';
+import { push_ticket_change, set_ticket_attachments, set_ticket_changes, set_ticket_data } from '../actions';
 import Loading from '../components/Loading';
 import TicketComponent from '../components/Ticket';
 import Trac from '../lib/trac';
@@ -157,73 +157,6 @@ class Ticket extends React.PureComponent {
 
 				// ...and reload the changes.
 				this.loadChanges();
-			});
-	}
-
-	onUpload( upload ) {
-		const { dispatch, id, user } = this.props;
-		const { data, description, filename } = upload;
-
-		const ticket = parseInt( id, 10 );
-
-		const parameters = [
-			// int ticket
-			ticket,
-
-			// string filename
-			filename,
-
-			// string description
-			description,
-
-			// Binary data
-			data,
-
-			// boolean replace=True
-			false,
-		];
-		const types = {
-			// Binary data
-			3: 'base64',
-		};
-
-		// Optimistically render.
-		const tempTimestamp = parseInt( Date.now() / 1000, 10 );
-		const change = [
-			// timestamp
-			tempTimestamp,
-
-			// author
-			user.username,
-
-			// field
-			'attachment',
-
-			// oldval
-			'',
-
-			// newval (filename)
-			filename,
-
-			// permanent
-			true,
-		];
-		const tempAttachment = {
-			id: filename,
-			description,
-			size: 0,
-			timestamp: tempTimestamp,
-			author: user.username,
-			isUploading: true,
-		};
-		dispatch( push_ticket_change( ticket, change ) );
-		dispatch( push_attachment( ticket, tempAttachment ) );
-
-		// And finally, save.
-		this.api.call( 'ticket.putAttachment', parameters, types )
-			.then( () => {
-				// Reload changes and attachments.
-				this.loadTicketAndChanges( id, 'attachments' );
 			});
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ import './index.css';
 
 // Prepare initial state for the store.
 const initialState = {
+	prs: {
+		state: null,
+		items: [],
+	},
 	query: {
 		params: {},
 		results: [],

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 
 import App from './App';
@@ -23,8 +24,13 @@ if ( existing ) {
 	initialState.user = JSON.parse( existing );
 }
 
+// Prepare middleware.
+const middleware = applyMiddleware(
+	thunk,
+);
+
 // Actually create the store.
-const store = createStore( reducer, initialState );
+const store = createStore( reducer, initialState, middleware );
 
 // Now, render.
 const render = App => {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,12 +1,14 @@
 import { combineReducers } from 'redux';
 
 import components from './components';
+import prs from './prs';
 import query from './query';
 import tickets from './tickets';
 import user from './user';
 
 export default combineReducers({
 	components,
+	prs,
 	query,
 	tickets,
 	user,

--- a/src/reducers/prs.js
+++ b/src/reducers/prs.js
@@ -1,0 +1,21 @@
+import { RECEIVE_PRS, REQUEST_PRS } from '../actions';
+
+export default function prs( state = {}, action ) {
+	switch ( action.type ) {
+		case REQUEST_PRS:
+			return {
+				...state,
+				status: 'loading',
+			};
+
+		case RECEIVE_PRS:
+			return {
+				...state,
+				status: 'loaded',
+				items: [ ...action.prs ]
+			};
+
+		default:
+			return state;
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5037,6 +5037,10 @@ react-router-dom@^4.1.2:
     prop-types "^15.5.4"
     react-router "^4.1.1"
 
+react-router-modal@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/react-router-modal/-/react-router-modal-1.1.13.tgz#1d21508800d1557894e33c2cb691885c0938bc4b"
+
 react-router@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.1.2.tgz#7ae027341abc42eb08ad9f7a8cac08d0563672ce"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5202,6 +5202,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
 redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"


### PR DESCRIPTION
![not-trac-pull](https://user-images.githubusercontent.com/21655/29259258-a0ad39dc-8104-11e7-9012-afaeab501ada.gif)

Adds a pull request selector overlay (using react-router-modal, but directly/without a route).

Automatically generates the patch description in the form `{ pull.title } (From https://github.com/WordPress/wordpress-develop/pulls/${ pull.number })`, but can still be customised just like any other patch. Patches in this format are also parsed out and displayed differently.

<img width="607" alt="screenshot 2017-08-14 16 05 24" src="https://user-images.githubusercontent.com/21655/29260047-890dade2-810a-11e7-903d-d65980f896cc.png">


Fixes #4.