### PR TITLE
Avoid double-encoding URLs

### DIFF
--- a/src/components/TicketStatus.js
+++ b/src/components/TicketStatus.js
@@ -31,7 +31,7 @@ export default class TicketStatus extends React.PureComponent {
 				<p className="TicketStatus-components-list">
 					<span className="TicketStatus-component">
 						<span className="dashicons dashicons-awards"></span>
-						<Link to={ `/component/${ encodeURIComponent( attributes.component ) }`}>
+						<Link to={ `/component/${ attributes.component }`}>
 							<Tag name={ attributes.component } />
 						</Link>
 					</span>

--- a/src/containers/Summary.js
+++ b/src/containers/Summary.js
@@ -92,7 +92,7 @@ class Summary extends React.PureComponent {
 				<h2>Browse by Component</h2>
 				<p className="Summary-components">
 					{ Object.values( components ).map( component => <span key={ component.name }>
-						<Link to={ `/component/${ encodeURIComponent( component.name ) }`}>
+						<Link to={ `/component/${ component.name }`}>
 							<Tag name={ component.name } />
 						</Link>
 						{/*


### PR DESCRIPTION
It appears that React Router is already encoding these internally, where needed, but was avoiding double-encoding of spaces only. Unfortunately, this was breaking the "Options, Meta APIs" link (and others with a comma).