### PR TITLE
Fix description check

### DIFF
--- a/src/components/TicketChanges.js
+++ b/src/components/TicketChanges.js
@@ -82,7 +82,7 @@ export default class TicketChanges extends React.PureComponent {
 				const icon = <span className="dashicons dashicons-upload"></span>;
 				let description = attachments && patch in attachments && attachments[ patch ].description;
 				let pullLink = null;
-				if ( description && description.indexOf( 'https://github.com/WordPress/wordpress-develop/pull/' ) ) {
+				if ( description && 0 < description.indexOf( 'https://github.com/WordPress/wordpress-develop/pull/' ) ) {
 					pullLink = description.match( /(https:\/\/github.com\/WordPress\/wordpress-develop\/pull\/\d+)/i )[ 1 ];
 					description = description.replace(
 						/\(From (https:\/\/github.com\/WordPress\/wordpress-develop\/pull\/\d+)\)/,


### PR DESCRIPTION
This fixes a bug in `TicketChanges`, where the check for whether the
description is from GitHub could produce false positives.

See #21.